### PR TITLE
Tell TSC how to find d.ts file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "electron"
   ],
   "main": "./lib/edge.js",
+  "types": "electron-edge-js.d.ts",
   "engines": {
     "node": ">= 6"
   },


### PR DESCRIPTION
This package has a Typescript `d.ts` file, however if used inside a Typescript project, the compiler won't know where to find the `d.ts` file. I've added the required `package.json` entry so the compiler will be able to automatically grab the `d.ts` file.

Here is the link to the [Typescript documentation](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package) describing what I did.