### PR TITLE
Fix typescript d.ts file

### DIFF
--- a/electron-edge-js.d.ts
+++ b/electron-edge-js.d.ts
@@ -1,5 +1,6 @@
 declare module 'electron-edge-js' {
-    function func<TInput, TOutput>(language: string = 'cs', params: string | Function | Params | Source | TSQL): Func<TInput, TOutput>
+    function func<TInput, TOutput>(params: string | Function | Params | Source | TSQL): Func<TInput, TOutput>
+    function func<TInput, TOutput>(language: string, params: string | Function | Params | Source | TSQL): Func<TInput, TOutput>
     interface Params {
         assemblyFile: string
         typeName?: string


### PR DESCRIPTION
Fixes #18 (Same fix will address agracio/edge-js#36) where TSC throws `A parameter initializer is only allowed in a function or constructor implementation.`

Overloads function type definition in `d.ts` file for `func`.
