### PR TITLE
Fix for Electron 4.0

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -122,7 +122,9 @@
             'VCLinkerTool': {
               'AdditionalOptions': [
                 '/ignore:4248',
-                'shlwapi.lib'
+                'shlwapi.lib',
+				'/DELAYLOAD:"iojs.exe"',
+				'/DELAYLOAD:"node.exe"' 
               ]
             }
           }
@@ -147,7 +149,9 @@
             'VCLinkerTool': {
               'AdditionalOptions': [
                 '/ignore:4248',
-                'shlwapi.lib'
+                'shlwapi.lib',
+                '/DELAYLOAD:"iojs.exe"',
+                '/DELAYLOAD:"node.exe"'
               ]
             }
           }
@@ -242,7 +246,9 @@
             },
             'VCLinkerTool': {
               'AdditionalOptions': [
-                '/ignore:4248'
+                '/ignore:4248',
+                '/DELAYLOAD:"iojs.exe"',
+                '/DELAYLOAD:"node.exe"' 
               ]
             }
           }
@@ -264,7 +270,9 @@
             },
             'VCLinkerTool': {
               'AdditionalOptions': [
-                '/ignore:4248'
+                '/ignore:4248',
+                '/DELAYLOAD:"iojs.exe"',
+                '/DELAYLOAD:"node.exe"' 
               ]
             }
           }

--- a/binding.gyp
+++ b/binding.gyp
@@ -123,8 +123,8 @@
               'AdditionalOptions': [
                 '/ignore:4248',
                 'shlwapi.lib',
-				'/DELAYLOAD:"iojs.exe"',
-				'/DELAYLOAD:"node.exe"' 
+                '/DELAYLOAD:"iojs.exe"',
+                '/DELAYLOAD:"node.exe"' 
               ]
             }
           }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "nan": "^2.10.0"
   },
   "devDependencies": {
+    "electron-rebuild": "^1.8.4",
     "mocha": "5.1.1",
     "mocha-junit-reporter": "^1.17.0"
   },

--- a/src/common/edge.cpp
+++ b/src/common/edge.cpp
@@ -4,6 +4,11 @@
 
 #include "edge_common.h"
 
+#include <windows.h>
+
+#include <delayimp.h>
+#include <string.h>  
+
 #ifdef HAVE_CORECLR
 #include "../CoreCLREmbedding/edge.h"
 #endif
@@ -85,5 +90,20 @@ NODE_MODULE(edge_coreclr, init);
 #else
 NODE_MODULE(edge_nativeclr, init);
 #endif
+
+static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+    HMODULE m;
+    if (event != dliNotePreLoadLibrary)
+        return NULL;
+
+    if (_stricmp(info->szDll, "iojs.exe") != 0 &&
+        _stricmp(info->szDll, "node.exe") != 0)
+        return NULL;
+
+    m = GetModuleHandle(NULL);
+    return (FARPROC)m;
+}
+
+decltype(__pfnDliNotifyHook2) __pfnDliNotifyHook2 = load_exe_hook;
 
 // vim: ts=4 sw=4 et:


### PR DESCRIPTION
Possible fix for issue with Electron 4.0 ([https://github.com/agracio/electron-edge-js/issues/32](url)). With command 

`"./node_modules/.bin/electron-rebuild" --version 4.0.4`

the output native modules do not produce the errors.