### PR TITLE
Updates on building (also fixes issue #38 - Will not find node-gyp installed in a different location)

### DIFF
--- a/tools/build.bat
+++ b/tools/build.bat
@@ -67,7 +67,8 @@ if "%3" equ "7.9.0" (
 
 echo Building edge.node %FLAVOR% for node.js %2 v%3
 set NODEEXE=%DESTDIR%\node.exe
-set GYP=%APPDATA%\npm\node_modules\node-gyp\bin\node-gyp.js
+FOR /F "tokens=* USEBACKQ" %%F IN (`npm config get prefix`) DO (SET NODEBASE=%%F)
+set GYP=%NODEBASE%\node_modules\node-gyp\bin\node-gyp.js
 if not exist "%GYP%" (
     echo Cannot find node-gyp at %GYP%. Make sure to install with npm install node-gyp -g
     exit /b -1

--- a/tools/install.js
+++ b/tools/install.js
@@ -10,6 +10,12 @@ if (process.platform === 'win32') {
 
 	function copyFile(filePath, filename) {
 		return function(copyToDir) {
+			console.log( 'copy '+filename+' from '+filePath+' to '+ copyToDir );
+			outFile = path.resolve(copyToDir, filename);
+			if ( fs.existsSync( outFile ) ) {
+				// clear readonly: add write permission to ogw (222 octal -> 92 hex -> 146 decimal)
+				fs.chmodSync( outFile, fs.statSync(outFile).mode | 146 )
+			}
 			fs.writeFileSync(path.resolve(copyToDir, filename), fs.readFileSync(filePath));
 		};
 	}


### PR DESCRIPTION
get path to node-gyp.js based on npm prefix configuration instead of fixed appdata path.

copyFile now checks for an existing target file and ensures it has write permission (clear read only on windows)