### PR TITLE
Fix path resolution for asar archives

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-    , path = require('path')
+    , path = require('./electronPath')
     , builtEdge = path.resolve(__dirname, '../build/Release/' + (process.env.EDGE_USE_CORECLR || !fs.existsSync(path.resolve(__dirname, '../build/Release/edge_nativeclr.node')) ? 'edge_coreclr.node' : 'edge_nativeclr.node'))
     , edge;
 
@@ -110,7 +110,7 @@ exports.func = function(language, options) {
         }
 
         try {
-            options.compiler = compiler.getCompiler();
+            options.compiler = path.normalizeElectronPath(compiler.getCompiler());
         }
         catch (e) {
             throw new Error("The '" + compilerName + "' module required to compile the '" + language + "' language " +

--- a/lib/electronPath.js
+++ b/lib/electronPath.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const _path = require('path');
+
+const normalizeElectronPath = function(s) {
+  const alp = s.replace(/app\.asar(?!\.unpacked)/g, 'app.asar.unpacked');
+
+  let inAsarUnpacked = false;
+
+  if (fs.existsSync(alp)) {
+      inAsarUnpacked = true;
+  } else {
+      try {
+          require.resolve(alp);
+          inAsarUnpacked = true;
+      } catch(e) {}
+  }
+
+  return inAsarUnpacked ? alp : s;
+}
+
+const join = function() {
+  return normalizeElectronPath(_path.join.apply(this, arguments));
+}
+
+const resolve = function() {
+  return normalizeElectronPath(_path.resolve.apply(this, arguments));
+}
+
+const normalize = function() {
+  return normalizeElectronPath(_path.normalize.apply(this, arguments));
+}
+
+module.exports = {
+  join,
+  resolve,
+  normalize,
+  normalizeElectronPath,
+};


### PR DESCRIPTION
Fixes #62

Also users must be aware, that path resolution inside their code is steel not handled automatically.

For example if you have something like this:
```cs
#r "${path.join(__dirname, 'modules/MyModule.dll')}"
```
...you should use patched version of `path.join` function. For inspiration (or copy-past) you could take a look at [this](https://gist.github.com/akozhemiakin/98eca9185b3ba560c8993ce187028b98)