### PR TITLE
Bug: Fix install.js failure thought dir as file

### DIFF
--- a/tools/whereis.js
+++ b/tools/whereis.js
@@ -11,7 +11,7 @@ module.exports = function() {
     		var filename = arguments[j];
 	        var filePath = path.join(directories[i], filename);
 
-	        if (fs.existsSync(filePath)) {
+	        if (fs.existsSync(filePath) && fs.lstatSync(filePath).isFile()) {
 	            return filePath;
 	        }
 	    }


### PR DESCRIPTION
This is the same bug we found at edge-cs. So port
the fix here too.

For detailed bug descriptor
  https://github.com/tjanczuk/edge-cs/issues/12

For the fix at edge-cs
  https://github.com/tjanczuk/edge-cs/pull/13