### PR TITLE
Fixed issue with paths that have a unicode character in them

### DIFF
--- a/src/double/Edge.js/dotnet/EdgeJs.cs
+++ b/src/double/Edge.js/dotnet/EdgeJs.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -74,6 +75,9 @@ namespace EdgeJs
         [DllImport("node.dll", EntryPoint = "?Start@node@@YAHHQEAPEAD@Z", CallingConvention = CallingConvention.Cdecl)]
         static extern int NodeStartx64(int argc, string[] argv);
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+        private static extern int GetShortPathName(string LongPath, StringBuilder ShortPath, int BufferSize);
+
         [DllImport("kernel32.dll", EntryPoint = "LoadLibrary")]
         static extern int LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string lpLibFileName);
 
@@ -114,7 +118,14 @@ namespace EdgeJs
                                     argv.Add(p);
                                 }
                             }
-                            argv.Add(Path.Combine(AssemblyDirectory, "edge", "double_edge.js"));
+
+                            // Workaround for unicode characters in path
+                            string path = AssemblyDirectory + "\\edge\\double_edge.js";
+                            StringBuilder shortPath = new StringBuilder(255);
+                            int result = GetShortPathName(path, shortPath, shortPath.Capacity);
+                            argv.Add(shortPath.ToString());
+                            // End workaround for unicode characters in path
+                            
                             argv.Add($"-EdgeJs:{Path.Combine(edgeDirectory, "EdgeJs.dll")}");
                             nodeStart(argv.Count, argv.ToArray());
                             waitHandle.Set();


### PR DESCRIPTION
The module doesn't work at all if it's run from a folder that contains a unicode character. This is a potential fix that fixes the issue.

To reproduce the issue, create the following folder "blaž" without quotes and then run any electron-edge-js project from there, it will fail with an error along the lines of:

Could not load file or assembly 'file://C:\blaï¿ï¾¾\app\resources\app.asar.unpacked\node_modules\edge-cs\lib\edge-cs.dll' or one of its dependencies.

As you can see, the unicode character is butchers in the error message