### PR TITLE
Added preprocessor check for arch64 into the GetOSArchitecture function

### DIFF
--- a/src/CoreCLREmbedding/coreclrembedding.cpp
+++ b/src/CoreCLREmbedding/coreclrembedding.cpp
@@ -85,7 +85,7 @@ pal::string_t GetOSArchitecture()
 	return _X("x86");
 #elif defined __ia64 || defined _M_IA64 || defined __ia64__ || defined __x86_64__ || defined _M_X64
 	return _X("x64");
-#elif defined ARM || defined __arm__ || defined _ARM
+#elif defined ARM || defined __arm__ || defined _ARM || defined __aarch64__
 	return _X("arm");
 #endif
 }


### PR DESCRIPTION
On M2 MAC, GetOSArchitecture does not return anything, so the library fails silently. 
It works by adding the __aarch64__ definition to the check.