### PR TITLE
Fix v8::External::Value calls for the new ExternalPointerTypeTag API

### DIFF
--- a/src/CoreCLREmbedding/coreclrfunc.cpp
+++ b/src/CoreCLREmbedding/coreclrfunc.cpp
@@ -16,7 +16,11 @@ NAN_METHOD(coreClrFuncProxy)
     DBG("coreClrFuncProxy");
     Nan::EscapableHandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    CoreClrFuncWrap* wrap = (CoreClrFuncWrap*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     CoreClrFuncWrap* wrap = (CoreClrFuncWrap*)(correlator->Value());
+#endif
     CoreClrFunc* clrFunc = wrap->clrFunc;
     info.GetReturnValue().Set(clrFunc->Call(info[0], info[1]));
 }

--- a/src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp
+++ b/src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp
@@ -6,7 +6,11 @@ NAN_METHOD(coreClrV8FuncCallback)
 
     Nan::HandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    CoreClrNodejsFuncInvokeContext* context = (CoreClrNodejsFuncInvokeContext*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     CoreClrNodejsFuncInvokeContext* context = (CoreClrNodejsFuncInvokeContext*)(correlator->Value());
+#endif
 
     if (!info[0]->IsUndefined() && !info[0]->IsNull())
     {

--- a/src/dotnet/clrfunc.cpp
+++ b/src/dotnet/clrfunc.cpp
@@ -12,7 +12,11 @@ NAN_METHOD(clrFuncProxy)
     DBG("clrFuncProxy");
     Nan::HandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    ClrFuncWrap* wrap = (ClrFuncWrap*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     ClrFuncWrap* wrap = (ClrFuncWrap*)(correlator->Value());
+#endif
     ClrFunc^ clrFunc = wrap->clrFunc;
     info.GetReturnValue().Set(clrFunc->Call(info[0], info[1]));
 }

--- a/src/dotnet/nodejsfuncinvokecontext.cpp
+++ b/src/dotnet/nodejsfuncinvokecontext.cpp
@@ -21,7 +21,11 @@ NAN_METHOD(v8FuncCallback)
     DBG("v8FuncCallback");
     Nan::HandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    NodejsFuncInvokeContextWrap* wrap = (NodejsFuncInvokeContextWrap*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     NodejsFuncInvokeContextWrap* wrap = (NodejsFuncInvokeContextWrap*)(correlator->Value());
+#endif
     NodejsFuncInvokeContext^ context = wrap->context;
     wrap->context = nullptr;
     if (!info[0]->IsUndefined() && !info[0]->IsNull())

--- a/src/mono/clrfunc.cpp
+++ b/src/mono/clrfunc.cpp
@@ -21,7 +21,11 @@ NAN_METHOD(clrFuncProxy)
     DBG("clrFuncProxy");
     Nan::HandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    ClrFuncWrap* wrap = (ClrFuncWrap*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     ClrFuncWrap* wrap = (ClrFuncWrap*)(correlator->Value());
+#endif
     ClrFunc* clrFunc = wrap->clrFunc;
     info.GetReturnValue().Set(clrFunc->Call(info[0], info[1]));
 }

--- a/src/mono/nodejsfuncinvokecontext.cpp
+++ b/src/mono/nodejsfuncinvokecontext.cpp
@@ -5,7 +5,11 @@ NAN_METHOD(v8FuncCallback)
     DBG("v8FuncCallback");
     Nan::HandleScope scope;
     v8::Local<v8::External> correlator = v8::Local<v8::External>::Cast(info[2]);
+#ifdef V8_EXTERNAL_POINTER_TAG_COUNT
+    NodejsFuncInvokeContext* context = (NodejsFuncInvokeContext*)(correlator->Value(v8::kExternalPointerTypeTagDefault));
+#else
     NodejsFuncInvokeContext* context = (NodejsFuncInvokeContext*)(correlator->Value());
+#endif
     if (!info[0]->IsUndefined() && !info[0]->IsNull())
     {
        context->Complete((MonoObject*)exceptionV82stringCLR(info[0]), NULL);


### PR DESCRIPTION
Recent V8 versions (currently shipped by Chromium/Electron; not yet in released Node.js) added an ExternalPointerTypeTag parameter to v8::External::Value():
```
  void* Value(ExternalPointerTypeTag tag) const;   // V8 with sandbox tagging
  void* Value() const;                             // earlier V8
```
The old zero-arg overload was removed, so edge-js fails to compile against Electron 42's V8 with errors like:
```
  src/dotnet/clrfunc.cpp(15): error C2660:
    'v8::External::Value': function does not take 0 arguments
```

The companion fix for nan's own callsites (which edge-js depends on) is in nodejs/nan#1015; both fixes are needed for end-to-end builds against Electron 42.